### PR TITLE
updated nightwatch-commands repo

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
     "grunt": "~0.4.1",
     "nightwatch": "git+https://github.com/mobify/nightwatch.git#mobify",
-    "nightwatch-commands": "git+https://a1f92e41a282773dfd449d413f368e967380c1ad:x-oauth-basic@github.com/mobify/nightwatch-commands.git"
+    "nightwatch-commands": "git+https://github.com/mobify/nightwatch-commands.git"
   }
 }


### PR DESCRIPTION
Because Nightwatch Commands is now public, we can get rid of the auth token. 

**Status**: _Opened for visibility_

**Reviewers**: @scalvert 
## Changes
- Corrects the git repo to not use the new auth token
## How to test-drive this PR
- generate a test folder
- it should install the nightwatch-commands repo
