### PR TITLE
Add flag to allow running insecure content

### DIFF
--- a/app/templates/nightwatch/nightwatch.json
+++ b/app/templates/nightwatch/nightwatch.json
@@ -30,7 +30,8 @@
                 "chromeOptions": {
                     "args": [
                         "--user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A4449d Safari/9537.53",
-                        "--window-size=320,640"
+                        "--window-size=320,640",
+                        "--allow-running-insecure-content"
                     ]
                 },
                 "javascriptEnabled": true,
@@ -56,7 +57,8 @@
                 "chromeOptions": {
                     "args": [
                         "--user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A4449d Safari/9537.53",
-                        "--window-size=320,640"
+                        "--window-size=320,640",
+                        "--allow-running-insecure-content"
                     ]
                 },
                 "javascriptEnabled": true,


### PR DESCRIPTION
Added Chrome argument to allow insecure content to run, useful for HTTPS domains

Status: **Opened for visibility**
Reviewers: **@scalvert**
## Changes
- "--allow-running-insecure-content" flag added to Chrome args for default and saucelabs settings in nightwatch.json
