### PR TITLE
Change template package.json to use npm versions instead of git URLs

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "grunt": "~0.4.1",
-    "nightwatch": "git+https://github.com/beatfactor/nightwatch.git",
-    "nightwatch-commands": "git+https://github.com/mobify/nightwatch-commands.git"
+    "nightwatch": "0.4.14",
+    "nightwatch-commands": "0.0.1"
   }
 }


### PR DESCRIPTION
Update generated package.json to use NPM versions

**Status**: _Opened for visibility_

**Reviewers**: @scalvert @kbingman 
## Changes

Inside package.json:
- Changed nightwatch entry from git URL to a pinned version 0.4.14
- Changed nightwatch-commands entry from git URL to a pinned version 0.0.1
## How to test-drive this PR
- Checkout branch
- Run `npm link`
- Run `yo nightwatch` in a new, empty directory
- Verify that the generated package.json file has pinned versions for nightwatch and nightwatch-commands
