### PR TITLE
Unpin nightwatch-commands NPM version in package.json

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
     "grunt": "~0.4.1",
     "nightwatch": "0.4.14",
-    "nightwatch-commands": ">=0.0.1"
+    "nightwatch-commands": "latest"
   }
 }


### PR DESCRIPTION
Unpin NPM version of nightwatch-commands for template package.json

**Status**: _Opened for visibility_

**Reviewers**: @scalvert 
## Changes
- Unpinned NPM version of nightwatch-commands in package.json
## How to test-drive this PR
- Checkout this branch
- Run `npm link`
- Run `yo nightwatch` in an empty directory
- Verify that generated package.json file has unpinned version
