### PR TITLE
Fix circle.yml for builds on CircleCI

### DIFF
--- a/app/templates/_circle.yml
+++ b/app/templates/_circle.yml
@@ -1,10 +1,7 @@
-general:
-  build_dir: tests
-
 dependencies:
     override:
         - gem install sass compass
-        - npm install mobify-client
+        - npm install -g mobify-client
         - npm install
     post:
         - wget https://selenium.googlecode.com/files/selenium-server-standalone-2.39.0.jar
@@ -12,9 +9,8 @@ dependencies:
             background: true
 
 test:
-    pre:
-        - mobify preview:
+    override:
+        - compass compile && mobify preview:
             background: true
         - sleep 5
-    override:
         - grunt nightwatch


### PR DESCRIPTION
Updated circle.yml config file to ensure 1.1 builds integrate correctly with CircleCI

**Status**: _Opened for visibility_

**Reviewers**: @scalvert @kbingman 
## Changes
- Eliminate use of build_dir, which was previously overriding all commands' run path to ~/circleCheckoutDir/tests
- Install Mobify globally in Circle VM so `mobify` bash command is usable
- Eliminate the use of "pre:" test commands, as we are overriding Circle's inferred commands anyways
- Ensure CSS is compiled with `compass compile` before preview is run
## How to test-drive this PR
- Use the generator to add this circle.yml file to a 1.1 Nightwatch-enabled build (or override its existing circle.yml)
- Add this project to CircleCI for following
- Ensure that Nightwatch tests run correctly on CircleCI
