### PR TITLE
Clean node_modules directory to ensure cache issue does not halt tests

### DIFF
--- a/app/templates/_circle.yml
+++ b/app/templates/_circle.yml
@@ -1,5 +1,6 @@
 dependencies:
     override:
+        - rm -rf node_modules/
         - gem install sass compass
         - npm install -g mobify-client
         - npm install


### PR DESCRIPTION
Clean node_modules directory before dependency installs to bypass errand cache issue

**Status**: _Opened for visibility_

**Reviewers**: @scalvert @kbingman 
## Changes
- Nuke the node_modules/ (from an applied previous cache) before running dependency installs due to an issue with installing dependencies on a previous cache. (Tests would not run due to a duplicate function definition, reference: https://circleci.com/gh/mobify/mobifyjs-burlington-tablet/78)
## How to test-drive this PR
- Try and reproduce the CircleCI cache issue by rebuilding a previously successful build without clearing cache and verify that the tests halt due to the duplicate function definition
- Verify that the addition of the new command will resolve the cache issue
