### PR TITLE
Specify selenium log path to avoid root dir receiving log file

### DIFF
--- a/app/templates/nightwatch/nightwatch.json
+++ b/app/templates/nightwatch/nightwatch.json
@@ -7,7 +7,7 @@
     "selenium": {
         "start_process": true,
         "server_path": "./node_modules/nightwatch-commands/selenium/selenium-server.jar",
-        "log_path": "",
+        "log_path": "./node_modules/nightwatch-commands/selenium/",
         "host": "127.0.0.1",
         "port": 4444,
         "cli_args": {


### PR DESCRIPTION
Specify Selenium log path

**Status**: _Opened for visibility_

**Reviewers**: @scalvert @Helen-Mobify @mobify-derrick 
## Changes
- Funnelled selenium debug log file into `node_modules/nightwatch-commands/selenium` to avoid it polluting repo's root directory
## How to test-drive this PR
- Run test suite with new parameter
- Verify that `selenium-debug.log` file is placed into `nightwatch-commands/selenium` directory
