### PR TITLE
Validate project and bundle URLs

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -37,6 +37,9 @@ NightwatchGenerator.prototype.askFor = function askFor() {
                 if (!answer.length) {
                     return 'You must enter a URL.';
                 }
+                if (answer.substring(0,4) !== 'http') {
+                    return 'You must begin your URL with "http".';
+                }
                 return true;
             }
         },{

--- a/app/index.js
+++ b/app/index.js
@@ -38,7 +38,7 @@ NightwatchGenerator.prototype.askFor = function askFor() {
                     return 'You must enter a URL.';
                 }
                 if (answer.substring(0,4) !== 'http') {
-                    return 'You must begin your URL with "http".';
+                    return 'You must begin your project URL with "http".';
                 }
                 return true;
             }
@@ -46,7 +46,13 @@ NightwatchGenerator.prototype.askFor = function askFor() {
             type: 'input',
             name: 'bundleUrl',
             message: 'What is the URL of your Mobify bundle?',
-            default: 'http://localhost:8080'
+            default: 'http://localhost:8080',
+            validate: function (answer) {
+                if (answer.substring(0,4) !== 'http') {
+                    return 'You must begin your bundle URL with "http".';
+                }
+                return true;
+            }
         },
     ]
 

--- a/app/index.js
+++ b/app/index.js
@@ -38,7 +38,7 @@ NightwatchGenerator.prototype.askFor = function askFor() {
                     return 'You must enter a URL.';
                 }
                 if (answer.substring(0,4) !== 'http') {
-                    return 'You must begin your project URL with "http".';
+                    return 'You must begin your project URL with "http" or "https".';
                 }
                 return true;
             }
@@ -49,12 +49,12 @@ NightwatchGenerator.prototype.askFor = function askFor() {
             default: 'http://localhost:8080',
             validate: function (answer) {
                 if (answer.substring(0,4) !== 'http') {
-                    return 'You must begin your bundle URL with "http".';
+                    return 'You must begin your bundle URL with "http" or "https".';
                 }
                 return true;
             }
         },
-    ]
+    ];
 
     this.prompt(prompts, function (props) {
         this.siteUrl = props.siteUrl;


### PR DESCRIPTION
Validate project and bundle URLs

**Status**: _Opened for visibility_

**Reviewers**: @scalvert @mobify-derrick 
## Changes

While reviewing previous generator changes, I noticed that the generator does not have format validation for project or bundle URLs. This would lead to project URLs being entered without the prepended "http" and Nightwatch would halt the default tests and report an error. This PR's changes are a simple attempt at baking in some URL validation into the generator.
## How to test-drive this PR
- Checkout this branch
- `npm link` it to your instance of `yo`
- Run `yo nightwatch` in a new, empty directory (to avoid accidentally overwriting anything)
- Attempt to set the project or bundle URL without starting with "http"
- Set the URLs to a valid format and ensure `grunt nightwatch` runs default tests successfully
