### PR TITLE
Add a timeout to all circleCI commands

### DIFF
--- a/app/templates/_circle.yml
+++ b/app/templates/_circle.yml
@@ -1,14 +1,20 @@
 dependencies:
     override:
-        - gem install sass compass
-        - npm install -g mobify-client
-        - npm install
+        - gem install sass compass:
+            timeout: 600
+        - npm install -g mobify-client:
+            timeout: 600
+        - npm install:
+            timeout: 600
     post:
-        - chmod 755 ./node_modules/nightwatch-commands/selenium/drivers/chromedriver
+        - chmod 755 ./node_modules/nightwatch-commands/selenium/drivers/chromedriver:
+            timeout: 600
 
 test:
     override:
         - compass compile && mobify preview:
             background: true
+            timeout: 600
         - sleep 5
-        - grunt nightwatch
+        - grunt nightwatch:
+            timeout: 600


### PR DESCRIPTION
Add a timeout to all circleCI commands

**Status**: *Opened for visibility*
 
**Reviewers**: @scalvert @mobify-derrick @ellenmobify 
  
## Changes
- Add a 10 minute timeout to all CircleCI commands in `circle.yml`
(This should prevent CircleCI containers hanging in limbo due to a dependency install failure such as: https://circleci.com/gh/mobify/mobifyjs-burlington-tablet/447)
  
## How to test-drive this PR
- Checkout this branch
- Run `yo nightwatch` in a new, empty directory
- Ensure the generated `circle.yml` file includes the new timeout values for each CircleCI command
